### PR TITLE
fix jenkins image repo

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   jenkins:
-    image: jenkins:latest
+    image: jenkins/jenkins:lts
     ports:
       - "8080:8080"
       - "50000:50000"


### PR DESCRIPTION
Old repo is deprecated and jenkins from that repo fails to install plugins. You may also need to update this repo in your course documentation