### PR TITLE
Point to jenkins/jenkins:lts image within DockerHub

### DIFF
--- a/scripts/install_jenkins.sh
+++ b/scripts/install_jenkins.sh
@@ -14,7 +14,7 @@ usermod -aG docker ubuntu
 # run jenkins
 mkdir -p /var/jenkins_home
 chown -R 1000:1000 /var/jenkins_home/
-docker run -p 8080:8080 -p 50000:50000 -v /var/jenkins_home:/var/jenkins_home -d --name jenkins jenkins
+docker run -p 8080:8080 -p 50000:50000 -v /var/jenkins_home:/var/jenkins_home -d --name jenkins jenkins/jenkins:lts
 
 # show endpoint
 echo 'Jenkins installed'


### PR DESCRIPTION
If we don't point to jenkins/jenkins:lts image, than subsequent plugin updates will fail when attempting to install recommended plugins.