### PR TITLE
sonar.java.binaries property required

### DIFF
--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -15,7 +15,7 @@ node {
     stage('sonar-scanner') {
       def sonarqubeScannerHome = tool name: 'sonar', type: 'hudson.plugins.sonar.SonarRunnerInstallation'
       withCredentials([string(credentialsId: 'sonar', variable: 'sonarLogin')]) {
-        sh "${sonarqubeScannerHome}/bin/sonar-scanner -e -Dsonar.host.url=http://sonarqube:9000 -Dsonar.login=${sonarLogin} -Dsonar.projectName=gs-gradle -Dsonar.projectVersion=${env.BUILD_NUMBER} -Dsonar.projectKey=GS -Dsonar.sources=complete/src/main/ -Dsonar.tests=complete/src/test/ -Dsonar.language=java"
+        sh "${sonarqubeScannerHome}/bin/sonar-scanner -e -Dsonar.host.url=http://sonarqube:9000 -Dsonar.login=${sonarLogin} -Dsonar.projectName=gs-gradle -Dsonar.projectVersion=${env.BUILD_NUMBER} -Dsonar.projectKey=GS -Dsonar.sources=complete/src/main/ -Dsonar.tests=complete/src/test/ -Dsonar.language=java -Dsonar.java.binaries=."
       }
     }
 }


### PR DESCRIPTION
For latest Sonarcube cli builds - we need to specify binary

ReadMore at : https://stackoverflow.com/q/55939429/1525324

JenkinsError : ERROR: Error during SonarQube Scanner execution
org.sonar.java.AnalysisException: Please provide compiled classes of your project with sonar.java.binaries property