### PR TITLE
Fix groovy scripts to respect new security mechanism by github

### DIFF
--- a/job-dsl/nodejs.groovy
+++ b/job-dsl/nodejs.groovy
@@ -1,6 +1,6 @@
 job('NodeJS example') {
     scm {
-        git('git://github.com/wardviaene/docker-demo.git') {  node -> // is hudson.plugins.git.GitSCM
+        git('https://github.com/wardviaene/docker-demo.git') {  node -> // is hudson.plugins.git.GitSCM
             node / gitConfigName('DSL User')
             node / gitConfigEmail('jenkins-dsl@newtech.academy')
         }

--- a/job-dsl/nodejsdocker.groovy
+++ b/job-dsl/nodejsdocker.groovy
@@ -1,6 +1,6 @@
 job('NodeJS Docker example') {
     scm {
-        git('git://github.com/wardviaene/docker-demo.git') {  node -> // is hudson.plugins.git.GitSCM
+        git('https://github.com/wardviaene/docker-demo.git') {  node -> // is hudson.plugins.git.GitSCM
             node / gitConfigName('DSL User')
             node / gitConfigEmail('jenkins-dsl@newtech.academy')
         }

--- a/job-dsl/nodejsdocker.groovy
+++ b/job-dsl/nodejsdocker.groovy
@@ -14,7 +14,7 @@ job('NodeJS Docker example') {
     }
     steps {
         dockerBuildAndPublish {
-            repositoryName('wardviaene/docker-nodejs-demo')
+            repositoryName('nliakm/docker-nodejs-demo')
             tag('${GIT_REVISION,length=9}')
             registryCredentials('dockerhub')
             forcePull(false)

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -7,11 +7,12 @@ pipeline {
       }
     }
 
-    def myGradleContainer = docker.image('gradle:jdk8-alpine')
-    myGradleContainer.pull()
-
+    def myGradleContainer
+    
     stage('prep') {
         git url: 'https://github.com/wardviaene/gs-gradle.git'
+        def myGradleContainer = docker.image('gradle:jdk8-alpine')
+        myGradleContainer.pull()
     }
 
     stage('build') {      

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -7,13 +7,13 @@ node {
     }
 
     stage('build') {
-        agent {
-          docker {
-            args "-u root"
-            alwaysPull false
-            reuseNode true
-          }
-        }        
+      agent {
+        docker {
+          args "-u root"
+          alwaysPull false
+          reuseNode true
+        }
+      }        
       myGradleContainer.inside("-v ${env.HOME}/.gradle:/home/gradle/.gradle") {
         sh 'cd complete && /opt/gradle/bin/gradle build'
       }

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -1,4 +1,12 @@
 node {
+    agent {
+      docker {
+        args "-u root"
+        alwaysPull false
+        reuseNode true
+      }
+    }
+
     def myGradleContainer = docker.image('gradle:jdk8-alpine')
     myGradleContainer.pull()
 
@@ -6,14 +14,7 @@ node {
         git url: 'https://github.com/wardviaene/gs-gradle.git'
     }
 
-    stage('build') {
-      agent {
-        docker {
-          args "-u root"
-          alwaysPull false
-          reuseNode true
-        }
-      }        
+    stage('build') {      
       myGradleContainer.inside("-v ${env.HOME}/.gradle:/home/gradle/.gradle") {
         sh 'cd complete && /opt/gradle/bin/gradle build'
       }

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -7,6 +7,13 @@ node {
     }
 
     stage('build') {
+        agent {
+          docker {
+            args "-u root"
+            alwaysPull false
+            reuseNode true
+          }
+        }        
       myGradleContainer.inside("-v ${env.HOME}/.gradle:/home/gradle/.gradle") {
         sh 'cd complete && /opt/gradle/bin/gradle build'
       }

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -11,7 +11,8 @@ pipeline {
     
     stage('prep') {
         git url: 'https://github.com/wardviaene/gs-gradle.git'
-        def myGradleContainer = docker.image('gradle:jdk8-alpine')
+        
+        myGradleContainer = docker.image('gradle:jdk8-alpine')
         myGradleContainer.pull()
     }
 

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -1,4 +1,4 @@
-node {
+pipeline {
     agent {
       docker {
         args "-u root"

--- a/sonarqube/Jenkinsfile
+++ b/sonarqube/Jenkinsfile
@@ -1,22 +1,12 @@
-pipeline {
-    agent {
-      docker {
-        args "-u root"
-        alwaysPull false
-        reuseNode true
-      }
-    }
+node {
+    def myGradleContainer = docker.image('gradle:jdk8-alpine')
+    myGradleContainer.pull()
 
-    def myGradleContainer
-    
     stage('prep') {
         git url: 'https://github.com/wardviaene/gs-gradle.git'
-        
-        myGradleContainer = docker.image('gradle:jdk8-alpine')
-        myGradleContainer.pull()
     }
 
-    stage('build') {      
+    stage('build') {
       myGradleContainer.inside("-v ${env.HOME}/.gradle:/home/gradle/.gradle") {
         sh 'cd complete && /opt/gradle/bin/gradle build'
       }


### PR DESCRIPTION
Running DSL jobs from the groovy scripts are not working anymore. This is due to new security mechanism by github which are preventing unauthenticated cloning with git protocol:

error message:
```
git fetch --tags --force --progress -- git://github.com/wardviaene/docker-demo.git +refs/heads/*:refs/remotes/origin/* # timeout=10
ERROR: Error fetching remote repo 'origin'
hudson.plugins.git.GitException: Failed to fetch from git://github.com/wardviaene/docker-demo.git
	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:1001)
	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1242)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1302)
	at hudson.scm.SCM.checkout(SCM.java:540)
	at hudson.model.AbstractProject.checkout(AbstractProject.java:1215)
	at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:645)
	at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:85)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:517)
	at hudson.model.Run.execute(Run.java:1896)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
Caused by: hudson.plugins.git.GitException: Command "git fetch --tags --force --progress -- git://github.com/wardviaene/docker-demo.git +refs/heads/*:refs/remotes/origin/*" returned status code 128:
stdout: 
stderr: fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2671)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2096)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:84)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:618)
	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:999)
	... 11 more
ERROR: Error fetching remote repo 'origin'
```
Switching protocol to https inside the groovy scripts will fix this issue.